### PR TITLE
trigger loaded event when done

### DIFF
--- a/scripts/ace-extended.js
+++ b/scripts/ace-extended.js
@@ -353,6 +353,9 @@ window.localStorage||Object.defineProperty(window,"localStorage",new function(){
                 })();
             })();
         });
+        
+        // trigger loaded event when done
+        $textarea.trigger('loaded');
     };
 
     $(function() { // dom loaded


### PR DESCRIPTION
to get the ace instance via the getAce() method i need to wait until the editor is initialized:
´´´
	// ace editor tweaks
	$("#codeeditor").on('loaded', function() {
		var editor = $(this).getAce();
		editor.setOptions({
			maxLines: Infinity,
			tabSize: 2,
		});
´´´